### PR TITLE
fix nix 0.12 API changes

### DIFF
--- a/src/fetchgit.cc
+++ b/src/fetchgit.cc
@@ -97,14 +97,14 @@ extern "C" void fetchgit( nix::EvalState & state
       throw SysError("forking to run fetchgit");
     case 0:
       pipe.readSide = -1;
-      if (dup2(pipe.writeSide, STDOUT_FILENO) == -1)
+      if (dup2(pipe.writeSide.get(), STDOUT_FILENO) == -1)
         err(214, "duping pipe to stdout");
       /* const-correct, execv doesn't modify it c just has dumb casting rules */
       execv(fetchgit_path, const_cast<char * const *>(argv));
       err(212, "executing %s", fetchgit_path);
   }
   pipe.writeSide = -1;
-  auto path = nix::drainFD(pipe.readSide);
+  auto path = nix::drainFD(pipe.readSide.get());
 
   int status;
   errno = 0;

--- a/src/fetchgit.cc
+++ b/src/fetchgit.cc
@@ -78,7 +78,7 @@ extern "C" void fetchgit( nix::EvalState & state
   auto submodules_iter = args[0]->attrs->find(submodules_sym);
   auto do_submodules = submodules_iter == args[0]->attrs->end() ?
     true :
-    state.forceBool(*submodules_iter->value);
+    state.forceBool(*submodules_iter->value, *submodules_iter->pos);
 
   constexpr char fetchgit_path[] = NIXEXEC_LIBEXEC_DIR "/fetchgit.sh";
   const char * const argv[] = { fetchgit_path

--- a/src/fetchgit.cc
+++ b/src/fetchgit.cc
@@ -96,14 +96,14 @@ extern "C" void fetchgit( nix::EvalState & state
     case -1:
       throw SysError("forking to run fetchgit");
     case 0:
-      pipe.readSide.close();
+      pipe.readSide = -1;
       if (dup2(pipe.writeSide, STDOUT_FILENO) == -1)
         err(214, "duping pipe to stdout");
       /* const-correct, execv doesn't modify it c just has dumb casting rules */
       execv(fetchgit_path, const_cast<char * const *>(argv));
       err(212, "executing %s", fetchgit_path);
   }
-  pipe.writeSide.close();
+  pipe.writeSide = -1;
   auto path = nix::drainFD(pipe.readSide);
 
   int status;


### PR DESCRIPTION
Nix 0.12pre used in NixOS unstable broke the current release.
This patch fixes https://github.com/NixOS/nixpkgs/issues/22315